### PR TITLE
suggestion for finding current version

### DIFF
--- a/policy-editor-lite.bash
+++ b/policy-editor-lite.bash
@@ -797,7 +797,7 @@ function promptNewVersion() {
 
 	# Determine current version
 	currentVersion=$( echo ${policyName} | awk -F"[()]" '{print $2}' )	# For policy names where the version is inside parenthesis
-	# currentVersion=$( echo ${policyName} | awk -F"[-]" '{print $2}' )	# For policy names where the version is after a dash
+	# currentVersion=$( echo ${policyName} | egrep -o "([0-9]{1,}\.)+[0-9]{1,}" | xargs )	# For policy names where the version is after a dash
 	if [[ -z ${currentVersion} ]]; then
 		currentPackageName=$( xmllint --xpath "/policy/package_configuration/packages/package/name/text()" ${updatesDirectory}/policy-${policyID}.xml )
 


### PR DESCRIPTION
for our org, we use "verb - app - version" so in its current implementation, grepping the version fails for me. Originally I just changed mine to {print $3), however this caused my version number to be " X.X.X" as opposed to "X.X.X" and that caused issues as well. 

my suggestion in practice so far eliminates the need to specify whether the versioning is locked behind () or -. That said, this is assuming that there's nothing else in the policy name that would match a version number...